### PR TITLE
Fix "Failed to execute 'btoa' on 'Window'" error

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
               decodedBSearchPromises.push( decodeIndividualResponse(bsearchResponse) );
             }
             const decodedBSearchResponses = await Promise.all( decodedBSearchPromises );
-            entry.response.content.text = btoa(decodedBSearchResponses.join('\n'));
+            entry.response.content.text = btoa(unescape(encodeURIComponent(decodedBSearchResponses.join('\n'))));
           }
         }
 


### PR DESCRIPTION
Whenever I used the tool (in Google Chrome), I got the following error:

```
Uncaught (in promise) DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
    at reader.onload (https://drewdaemon.github.io/kibana-har-decoder/:56:43)
reader.onload	@	kibana-har-decoder/:56
load (async)		
handleFile	@	kibana-har-decoder/:40
```

It seems to be working better with these changes.